### PR TITLE
Trello's filter indicator html must have changed

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -10,7 +10,7 @@ function Filter(debug) {
 	};
 	
 	var retrieveCurrentFilterStatus= function() {
-		return $('.js-filter-cards').hasClass('is-on');
+		return !($('.js-filter-cards-indicator').hasClass('hide'));
 	};
 	
 	var initialize= function() {


### PR DESCRIPTION
Have not tested this but currently it's broken and I suspect this is what you want (having examined Trello in Chrome Developer Tools)
